### PR TITLE
Avoid infinite loop in BPR

### DIFF
--- a/librec/src/main/java/librec/ranking/BPR.java
+++ b/librec/src/main/java/librec/ranking/BPR.java
@@ -62,7 +62,7 @@ public class BPR extends IterativeRecommender {
 					u = Randoms.uniform(numUsers);
 					SparseVector pu = userCache.get(u);
 
-					if (pu.getCount() == 0)
+					if (pu.getCount() == 0 || pu.getCount() == numItems)
 						continue;
 
 					int[] is = pu.getIndex();


### PR DESCRIPTION
In the unlikely event of a user rating all items, the loop of looking for J will turn into an infinite loop. Hence users who rated all items can be skipped (they are uninteresting to BPR; just like users who have not rated any items)
